### PR TITLE
Forced root for use in build pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 # Docker image for Python Behavior Driven Development Pipeline
 FROM rofrano/nyu-devops-base:sp23
 
-RUN sudo apt-get update && \
-    sudo apt-get install -y chromium-driver python3-selenium
+# This build image needs to be root
+USER root
+
+RUN apt-get update && \
+    apt-get install -y chromium-driver python3-selenium
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ## ----------------------------------------------------------------------
-## Builder for creating Docker images that behave similar to Virtual
-## Machines for use with Vagrant. This takes advantage if the buildx
-## builder in docker which can cross-compile images for other targets.
+## Builder for creating Docker images on multiple platform architectures.
+## This takes advantage if the buildx builder in docker which can
+## cross-compile images for other targets.
 ## ----------------------------------------------------------------------
 
 # These can be overidden with env vars.
@@ -42,9 +42,9 @@ build:	## Build all of the project Docker images
 	docker buildx build --pull --platform=$(PLATFORM) --tag $(IMAGE) --push .
 
 .PHONY: run
-run:	## Run a vagrant VM using this image
+run:	## Run a container using this image
 	$(info Bringing up container with Docker...)
-	docker run --rm -v $(PWD)/app -w /app $(IMAGE) bash
+	docker run --rm -it -h nyu --user vscode -v $(PWD):/app -w /app $(IMAGE) bash
 
 .PHONY: remove
 remove:	## Stop and remove the buildx builder

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Your test job should look something like this:
 To run locally use:
 
 ```sh
-docker run --rm -it -v $(pwd):/app -w /app rofrano/pipeline-selenium bash
+docker run --rm -it -h nyu --user vscode -v $(pwd):/app -w /app rofrano/pipeline-selenium bash
 ```
 
-That will leave you at a `bash` prompt in the `/app` folder shared with your current working directory so that you can `pip install` your dependencies and start your testing.
+That will place you inside the container as the user `vscode` sitting at a `bash` prompt in the `/app` folder that has been shared with your current working directory so that you can `pip install` your dependencies and start your testing.
 
 ## License
 
-Copyright (c) 2022, John Rofrano. All rights reserved.
+Copyright (c) 2022, 2023 John Rofrano. All rights reserved.
 
 Licensed under the Apache License. See [LICENSE](LICENSE)
 


### PR DESCRIPTION
When switching to use the `nyu-devops-base` image, the user is `vscode`. Needed to change back to `root` so that this image can be used in a build pipeline.