### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,20 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v3.0.0
         
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3.0.0
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Docker Login
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v2
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5.0.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Received some warnings about deprecations during the v1.50 release GitHub Actions build so I updated all of the GitHub Actions to the latest versions:

- Updated `docker/setup-qemu-action` from `v1` to `v3.0.0`
- Updated `docker/setup-buildx-action` from `v1` to `v3.0.0`
- Updated `docker/login-action` from `v1 ` to `v3.0.0`
- Updated `docker/build-push-action` from `v2` to `v5.0.0`